### PR TITLE
Set nonexistent keys

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,5 +6,6 @@
       Max Laager++
       <https://rt.cpan.org/Ticket/Display.html?id=92237>
 
-    [ Misc ]
+    [ Other ]
+    - Setting values on non-existent keys will create the key with the value
     - Forked from Toby Inkster's JSON::Path 0.205

--- a/Changes
+++ b/Changes
@@ -1,4 +1,10 @@
 {{$NEXT}}
 
-- Added support for escaping reserved characters in paths
-- Initial revision. Forked from Toby Inkster's JSON::Path 0.205
+    [ Bug Fixes ]
+    - Add support for escaping reserved characters
+      Fixes RT #92237
+      Max Laager++
+      <https://rt.cpan.org/Ticket/Display.html?id=92237>
+
+    [ Misc ]
+    - Forked from Toby Inkster's JSON::Path 0.205

--- a/README.md
+++ b/README.md
@@ -101,7 +101,13 @@ JSONPath is described at [http://goessner.net/articles/JsonPath/](http://goessne
 - `set($object, $value, $limit)`
 
     Alters `$object`, setting the paths to `$value`. If set, then
-    `$limit` limits the number of changes made.
+    `$limit` limits the number of changes made. 
+
+    TAKE NOTE! This will create keys in $object. E.G.:
+
+        my $obj = { foo => 'bar' };
+        my $path = JSON::Path->new('$.baz');
+        $path->set($obj, 'bak'); # $obj->{baz} is created and set to 'bak'
 
     Returns the number of changes made.
 

--- a/lib/JSON/Path.pm
+++ b/lib/JSON/Path.pm
@@ -457,6 +457,12 @@ sub, which means you can assign to it:
   my $path = JSON::Path->new('$.name');
   $path->value($person) = "Bob";
 
+TAKE NOTE! This will create keys in $object. E.G.:
+
+    my $obj = { foo => 'bar' };
+    my $path = JSON::Path->new('$.baz');
+    $path->value($obj) = 'bak'; # $obj->{baz} is created and set to 'bak';
+
 =item C<<  paths($object)  >>
 
 As per C<values> but instead of returning structures which match the
@@ -593,9 +599,9 @@ in at least three other programming languages.
 
 Toby Inkster E<lt>tobyink@cpan.orgE<gt>.
 
-This module is pretty much a straight line-by-line port of the PHP
-JSONPath implementation (version 0.8.x) by Stefan Goessner.
-See L<http://code.google.com/p/jsonpath/>.
+=head1 MAINTAINER
+
+Kit Peters E<lt>popefelix@cpan.orgE<gt>
 
 =head1 CONTRIBUTORS
 

--- a/lib/JSON/Path.pm
+++ b/lib/JSON/Path.pm
@@ -470,7 +470,13 @@ the first result.
 =item C<<  set($object, $value, $limit)  >>
 
 Alters C<< $object >>, setting the paths to C<< $value >>. If set, then
-C<< $limit >> limits the number of changes made.
+C<< $limit >> limits the number of changes made. 
+
+TAKE NOTE! This will create keys in $object. E.G.:
+
+    my $obj = { foo => 'bar' };
+    my $path = JSON::Path->new('$.baz');
+    $path->set($obj, 'bak'); # $obj->{baz} is created and set to 'bak'
 
 Returns the number of changes made.
 

--- a/lib/JSON/Path.pm
+++ b/lib/JSON/Path.pm
@@ -6,6 +6,8 @@ package JSON::Path;
 
 # VERSION
 
+use Exporter::Tiny ();
+our @ISA       = qw/ Exporter::Tiny /;
 our $AUTHORITY = 'cpan:POPEFELIX';
 our $Safe      = 1;
 
@@ -15,7 +17,6 @@ use JSON::Path::Evaluator;
 use Scalar::Util qw[blessed];
 use LV ();
 
-use base q{Exporter};
 our @EXPORT_OK = qw/ jpath jpath1 jpath_map /;
 
 use overload '""' => \&to_string;

--- a/lib/JSON/Path/Evaluator.pm
+++ b/lib/JSON/Path/Evaluator.pm
@@ -6,7 +6,6 @@ use 5.008;
 
 # ABSTRACT: A module that recursively evaluates JSONPath expressions with native support for Javascript-style filters
 
-
 use Carp;
 use Carp::Assert qw(assert);
 use Exporter::Tiny ();
@@ -137,7 +136,7 @@ sub evaluate_jsonpath {
             croak qq{Unable to decode $json_object as JSON: $_};
         }
     }
-    
+
     my $want_ref = delete $args{want_ref} || 0;
     my $self = __PACKAGE__->new(
         root             => $json_object,
@@ -145,7 +144,7 @@ sub evaluate_jsonpath {
         _calling_context => wantarray ? 'ARRAY' : 'SCALAR',
         %args
     );
-    return $self->evaluate($expression, want_ref => $want_ref);
+    return $self->evaluate( $expression, want_ref => $want_ref );
 }
 
 =method evaluate 
@@ -170,8 +169,8 @@ of that matched portion.
 
 =cut
 
-sub evaluate { 
-    my ($self, $expression, %args) = @_;
+sub evaluate {
+    my ( $self, $expression, %args ) = @_;
 
     my $json_object = $self->{root};
 
@@ -179,7 +178,7 @@ sub evaluate {
 }
 
 sub _evaluate {    # This assumes that the token stream is syntactically valid
-    my ( $self, $obj, $token_stream, $want_ref) = @_;
+    my ( $self, $obj, $token_stream, $want_ref ) = @_;
 
     $token_stream ||= [];
 

--- a/lib/JSON/Path/Evaluator.pm
+++ b/lib/JSON/Path/Evaluator.pm
@@ -173,14 +173,13 @@ of that matched portion.
 sub evaluate { 
     my ($self, $expression, %args) = @_;
 
-    my $want_ref = delete $args{want_ref} || 0;
     my $json_object = $self->{root};
 
-    return $self->_evaluate( $json_object, [ tokenize($expression) ], $want_ref );
+    return $self->_evaluate( $json_object, [ tokenize($expression) ], $args{want_ref} );
 }
 
 sub _evaluate {    # This assumes that the token stream is syntactically valid
-    my ( $self, $obj, $token_stream, $want_ref ) = @_;
+    my ( $self, $obj, $token_stream, $want_ref) = @_;
 
     $token_stream ||= [];
 
@@ -248,8 +247,6 @@ sub _evaluate {    # This assumes that the token stream is syntactically valid
                     return $want_ref ? @{$got} : map { ${$_} } @{$got};
                 }
                 else {
-                    return if $want_ref && !${$got};    # KLUDGE
-
                     return $want_ref ? $got : ${$got};
                 }
             }

--- a/t/05set.t
+++ b/t/05set.t
@@ -85,4 +85,7 @@ is( $jpath->set( $object => 'Anon' ), 1, );
 
 is( $jpath->value($object), 'Anon', );
 
+$jpath = JSON::Path->new('$.store.book.0.publisher');
+is( $jpath->set( $object, 'Peculiar Publications' ), 1 );
+is( $jpath->value( $object ), 'Peculiar Publications' );
 done_testing;

--- a/t/06lvalue.t
+++ b/t/06lvalue.t
@@ -27,12 +27,22 @@ my $person = { name => "Robert", foo => { bar => [ 1, 2, 3 ] } };
 my $path = JSON::Path->new('$.name');
 $path->value($person) = "Bob";
 
-is_deeply( $person, { name => "Bob", foo => { bar => [ 1, 2, 3 ] } } );
+is_deeply( $person, { name => "Bob", foo => { bar => [ 1, 2, 3 ] } } , q{Setting 'name' changes only the 'name' key and nothing else});
 
 jpath1( $person, '$.name' )    = "Robbie";
 jpath1( $person, '$.foo.bar' ) = 12;
 
-is_deeply( $person, { name => "Robbie", foo => { bar => 12 } } );
+is_deeply( $person, { name => "Robbie", foo => { bar => 12 } }, q{jpath1() works as lvalue});
+$path->value($person) ||= 'Fred';
+is $person->{name}, 'Robbie', q{lvalue works with ||=};
+
+$path = JSON::Path->new('$.quux');
+$path->value($person) = 'alpha';
+is $person->{quux}, 'alpha', q{lvalue will create keys not previously extant};
+
+$path = JSON::Path->new('$.quuy');
+$path->value($person) ||= 'beta';
+is $person->{quuy}, 'beta', q{lvalue and ||= will create keys not previously extant};
 
 done_testing;
 

--- a/t/evaluator/refs.t
+++ b/t/evaluator/refs.t
@@ -7,11 +7,11 @@ my @EXPRESSIONS = (
     '$..book[-1:]'                                  => single_ref( sub { $_[0]->{store}{book}[-1] } ),
     '$.nonexistent' => sub {
         my ( $refs, $obj ) = @_;
-        is scalar @{$refs}, 0, 'Nonexistent path gives nothing back';
+        ok exists $obj->{nonexistent}, 'want_ref creates the key';
     },
     '$..nonexistent' => sub {
         my ( $refs, $obj ) = @_;
-        is scalar @{$refs}, 0, 'Nonexistent path gives nothing back';
+        is scalar @{$refs}, 0, 'Nonexistent recursive path gives nothing back';
     },
     '$.complex_array[?(@.type.code=="CODE_ALPHA")]' => single_ref( sub { $_[0]->{complex_array}[0] } ) ,
     '$.array[-1:]' => single_ref( sub { $_[0]->{array}[-1] } ),


### PR DESCRIPTION
Given

```
$obj = { 
    quux => 'one',
    quuy => 'two',
};
```

Then `JSON::Path->new('$.quuz')->set($obj, 'three')` will result in

```
$obj = { 
    quux => 'one',
    quuy => 'two',
    quuz => 'three',
};
```
