### PR TITLE
Pin dependency of List::Util to >= 1.48

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 {{$NEXT}}
 
+0.400     2017-07-17 17:44:44-05:00 America/Chicago
+
     [ Other ]
     Tokenizer has been rewritten and is now cleaner and 20% cooler.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ JSON::Path
 
 # VERSION
 
-version 0.400
+version 0.401
 
 # SYNOPSIS
 

--- a/dist.ini
+++ b/dist.ini
@@ -4,9 +4,11 @@ license = Perl_5
 copyright_holder = Kit Peters
 copyright_year   = 2016
 
-; authordep Pod::Elemental::Transformer::List 
-version = 0.400
+; authordep Pod::Elemental::Transformer::List
+version = 0.401
 [AutoPrereqs]
+[Prereqs]
+List::Util = 1.48
 [@Basic]
 [MetaJSON]
 [GithubMeta]


### PR DESCRIPTION
CPAN testers are showing a failure because their List::Util doesn't export "pairs()", which was introduced in List::Util 1.28. Pinning the dependency on the latest (as of this PR) List::Util 