### PR TITLE
Make values return the number of matches in scalar context

### DIFF
--- a/lib/JSON/Path.pm
+++ b/lib/JSON/Path.pm
@@ -111,7 +111,7 @@ sub map {
     my ( $self, $object, $coderef ) = @_;
     my $count;
     foreach my $path ( $self->paths( $object ) ) {
-        my $ref = JSON::Path::Evaluator::evaluate_jsonpath( $object, $path, want_ref => 1 );
+        my ($ref) = JSON::Path::Evaluator::evaluate_jsonpath( $object, $path, want_ref => 1 );
         ++$count;
         my $value = do {
             no warnings 'numeric';

--- a/lib/JSON/Path/Evaluator.pm
+++ b/lib/JSON/Path/Evaluator.pm
@@ -210,7 +210,7 @@ sub evaluate {
     }
 
     my @ret = $self->_evaluate( $json_object, $token_stream, $args{want_ref} );
-    return wantarray ? @ret : $ret[0];
+    return @ret;
 }
 
 sub _reftable_walker {

--- a/t/08context.t
+++ b/t/08context.t
@@ -1,0 +1,24 @@
+use Test::More;
+use JSON::Path;
+use JSON;
+
+my $object = from_json(<<'JSON');
+{
+    "elements": [
+        { "id": 1 },
+        { "id": 2 }
+    ],
+    "empty": null
+}
+JSON
+
+my $path1 = JSON::Path->new('$.elements[*]');
+my @arr   = $path1->values($object);
+is_deeply \@arr, [ { id => 1 }, { id => 2 } ], 'multiple values in list context';
+my $scal = $path1->values($object);
+cmp_ok $scal, '==', 2, 'multiple values in scalar context';
+
+my $path2 = JSON::Path->new('$.empty');
+ok !!$path2->values($object), 'boolean check for existing null is true';
+
+done_testing();


### PR DESCRIPTION
According to the documentation, the values() method is supposed to return the number of matches in scalar context.

> values($object)
> ...
> Returns a list of structures from within $object which match against the JSONPath expression. In scalar context, returns the number of matches.

Currently, it returns the first match if there are any and undef otherwise. That makes it impossible to differentiate a matched null from no matches in scalar context.

This change makes the values() method work as documented and adds a test case to cover that.