### PR TITLE
Fix issues with boolean data

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,10 @@
       Fixes RT #122529
       Thomas Helsel ++
 
+    - Non-array-like and non-hash-like refs work properly for paths and map.
+      Fixes RT #123381
+      Patrick Cronin++
+
     [ Other ]
     - Warnings at the calling line when attempting to set on a non-object via set() or value() as an lvalue
 

--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ Heiko Jansen <hjansen@cpan.org>.
 
 Mitsuhiro Nakamura <m.nacamura@gmail.com>
 
+Patrick Cronin <oshihuna@gmail.com>
+
 # COPYRIGHT AND LICENCE
 
 Copyright 2007 Stefan Goessner.

--- a/lib/JSON/Path/Evaluator.pm
+++ b/lib/JSON/Path/Evaluator.pm
@@ -216,8 +216,8 @@ sub evaluate {
 sub _reftable_walker {
     my ( $self, $json_object, $base_path ) = @_;
 
-    $base_path   ||= '$';
-    $json_object ||= $self->root;
+    $base_path   = defined $base_path   ? $base_path   : '$';
+    $json_object = defined $json_object ? $json_object : $self->root;
 
     my @entries = ( refaddr $json_object => $base_path );
 
@@ -251,7 +251,7 @@ sub _evaluate {    # This assumes that the token stream is syntactically valid
 
     return unless ref $obj;
 
-    $token_stream ||= [];
+    $token_stream = defined $token_stream ? $token_stream : [];
 
     while ( defined( my $token = shift @{$token_stream} ) ) {
         next if $token eq $TOKEN_CURRENT;

--- a/lib/JSON/Path/Evaluator.pm
+++ b/lib/JSON/Path/Evaluator.pm
@@ -221,7 +221,7 @@ sub _reftable_walker {
 
     my @entries = ( refaddr $json_object => $base_path );
 
-    if ( ref $json_object eq 'ARRAY' ) {
+    if ( _arraylike($json_object) ) {
         for ( 0 .. $#{$json_object} ) {
             my $path = sprintf q{%s['%d']}, $base_path, $_;
             if ( ref $json_object->[$_] ) {
@@ -232,7 +232,7 @@ sub _reftable_walker {
             }
         }
     }
-    else {
+    elsif ( _hashlike($json_object) ) {
         for my $index ( keys %{$json_object} ) {
             my $path = sprintf q{%s['%s']}, $base_path, $index;
             if ( ref $json_object->{$index} ) {
@@ -405,7 +405,10 @@ sub _get {
 
 sub _indices {
     my $object = shift;
-    return _hashlike($object) ? keys %{$object} : ( 0 .. $#{$object} );
+    return
+          _hashlike($object)  ? keys %{$object}
+        : _arraylike($object) ? ( 0 .. $#{$object} )
+        : ();
 }
 
 sub _hashlike {
@@ -576,7 +579,7 @@ sub _process_pseudo_js {
     if ( _hashlike($object) ) {
         @lhs = map { $self->_evaluate( $_, [@token_stream] ) } values %{$object};
     }
-    else {
+    elsif ( _arraylike($object) ) {
         for my $value ( @{$object} ) {
             my ($got) = $self->_evaluate( $value, [@token_stream] );
             push @lhs, $got;

--- a/t/04map.t
+++ b/t/04map.t
@@ -55,7 +55,8 @@ my $object = from_json(<<'JSON');
 		"bicycle": {
 			"color": "red",
 			"price": 19.95
-		}
+		},
+		"boolean": false
 	}
 }
 JSON

--- a/t/evaluator/paths.t
+++ b/t/evaluator/paths.t
@@ -28,6 +28,7 @@ subtest simple => sub {
     my @expressions = (
         '$.nonexistent'               => [ ],
         '$.simple'                    => [ $data{simple} ],
+        '$.boolean'                   => [ $data{boolean} ],
         '$.long_hash.key1.subkey2'    => [ $data{long_hash}{key1}{subkey2} ],
         '$.long_hash.key1'            => [ dclone $data{long_hash}{key1} ],
         q{$.complex_array[0]['foo']}  => [ $data{complex_array}[0]{foo} ],
@@ -91,6 +92,7 @@ sub sample_json {
     my $data = <<END;
 {
    "simple" : "Simple",
+   "boolean" : false,
    "hash" : {
       "key" : "value"
    },

--- a/t/evaluator/refs.t
+++ b/t/evaluator/refs.t
@@ -63,6 +63,7 @@ subtest simple => sub {
     my @expressions = (
         '$.array[-1:]'             => single_ref( sub { $_[0]->{array}[-1] } ),
         '$.simple'                 => single_ref( sub { $_[0]->{simple} } ),
+        '$.boolean'                => single_ref( sub { $_[0]->{boolean} } ),
         '$.long_hash.key1.subkey2' => single_ref( sub { $_[0]->{long_hash}{key1}{subkey2} } ),
         '$.multilevel_array.1.0.0' => single_ref( sub { $_[0]->{multilevel_array}[1][0][0] } ),
         '$.store.book[0].title'    => single_ref( sub { $_[0]->{store}{book}[0]{title} } ),
@@ -165,6 +166,7 @@ sub sample_json {
     my $data = <<END;
 {
    "simple" : "Simple",
+   "boolean": false,
    "hash" : {
       "key" : "value"
    },

--- a/t/evaluator/want_path.t
+++ b/t/evaluator/want_path.t
@@ -30,7 +30,8 @@ my $json = q({
             "author" : "J. R. R. Tolkien",
             "category" : "fiction"
          }
-      ]
+      ],
+      "open_for_the_holidays": false
    }
 });
 my $obj = decode_json($json);
@@ -41,6 +42,7 @@ my @expressions = (
     q{$.store.book[?($_->{author} eq "J. R. R. Tolkien")]} => q{$['store']['book']['3']},
     q{$.store.book[?($_->{category} eq "fiction")]} =>
         [ q{$['store']['book']['1']}, q{$['store']['book']['2']}, q{$['store']['book']['3']} ],
+    q{$.store.open_for_the_holidays} => q{$['store']['open_for_the_holidays']},
 );
 do_test(@expressions);
 done_testing;


### PR DESCRIPTION
[RT #123381](https://rt.cpan.org/Ticket/Display.html?id=123381) reports that `Can't locate object method "root" via package "JSON::Path::Evaluator" at <someone/elses/machine>/lib/perl5/JSON/Path/Evaluator.pm line 130.` is thrown when using the `map` method on JSON containing boolean data. I ran into this issue, and also found the same issue when using `paths`.

Although JSON::Path's documentation suggests [it works well with blessed objects](https://metacpan.org/pod/JSON::Path#Blessed-Objects) (such as the `JSON::PP::Boolean` instances that JSON booleans are decoded to), there are places in this module's implementation where it appears to think only arrayref and hashref data are possible.

Thie PR adds failing test data and cases using boolean data and then adjusts the implementation so the tests pass.