### PR TITLE
Allow AND and OR operators in filter expression

### DIFF
--- a/lib/JSON/Path/Evaluator.pm
+++ b/lib/JSON/Path/Evaluator.pm
@@ -12,7 +12,7 @@ use Exporter::Tiny ();
 use JSON::MaybeXS;
 use JSON::Path::Constants qw(:operators :symbols);
 use JSON::Path::Tokenizer qw(tokenize);
-use List::Util qw/pairs/;
+use List::Util qw/pairs uniq/;
 use Readonly;
 use Safe;
 use Scalar::Util qw/looks_like_number blessed refaddr/;
@@ -567,33 +567,44 @@ sub _filter_recursive {
 }
 
 sub _process_pseudo_js {
-    my ( $self, $object, $expression ) = @_;
+    my ( $self, $object, $expressions ) = @_;
 
-    my ( $lhs, $operator, $rhs ) = _parse_psuedojs_expression($expression);
+    my @expressions_or = split /\Q||\E/, $expressions;
+    my @matching_or;
 
-    my (@token_stream) = tokenize($lhs);
+    foreach my $expression (@expressions_or) {
+        my @expressions_and = split /\Q&&\E/, $expression;
+        my %matching_and;
 
-    my $index;
+        foreach my $expression (@expressions_and) {
 
-    my @lhs;
-    if ( _hashlike($object) ) {
-        @lhs = map { $self->_evaluate( $_, [@token_stream] ) } values %{$object};
-    }
-    elsif ( _arraylike($object) ) {
-        for my $value ( @{$object} ) {
-            my ($got) = $self->_evaluate( $value, [@token_stream] );
-            push @lhs, $got;
+            my ( $lhs, $operator, $rhs ) = _parse_psuedojs_expression($expression);
+
+            my (@token_stream) = tokenize($lhs);
+
+            my @lhs;
+            if ( _hashlike($object) ) {
+                @lhs = map { $self->_evaluate( $_, [@token_stream] ) } values %{$object};
+            }
+            elsif ( _arraylike($object) ) {
+                for my $value ( @{$object} ) {
+                    my ($got) = $self->_evaluate( $value, [@token_stream] );
+                    push @lhs, $got;
+                }
+            }
+
+            # get indexes that pass compare()
+            for ( 0 .. $#lhs ) {
+                my $val = $lhs[$_];
+                $matching_and{$_}++ if _compare( $operator, $val, $rhs );
+            }
+        }
+        while (my ($idx, $val) = each(%matching_and)) {
+            push @matching_or, $idx if ($val == @expressions_and);
         }
     }
 
-    # get indexes that pass compare()
-    my @matching;
-    for ( 0 .. $#lhs ) {
-        my $val = $lhs[$_];
-        push @matching, $_ if _compare( $operator, $val, $rhs );
-    }
-
-    return @matching;
+    return uniq @matching_or;
 }
 
 sub _parse_psuedojs_expression {

--- a/t/filter_expression_and_or.t
+++ b/t/filter_expression_and_or.t
@@ -1,0 +1,99 @@
+=head1 PURPOSE
+
+Test expressions that use AND (&&) and/or OR (||)
+within the filter part of the path.
+
+=cut
+
+use Test::More;
+use JSON::Path::Evaluator qw/evaluate_jsonpath/;
+
+my $json = q@{
+    "Competency" : [
+        {
+            "level" : 75,
+            "name" : "Marketing"
+        },
+        {
+            "level" : 500,
+            "name" : "Something Else"
+        }
+    ]
+}@;
+
+my @data;
+
+### AND test
+@data = evaluate_jsonpath($json, '$.Competency[?(@.level>=0 && @.level<25)].name');
+is(@data, 0, 'Nothing between 0 and 25');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.level<25 && @.level>=0)].name');
+is(@data, 0, 'Nothing between 25 and 0');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.level>=0 && @.level<100)].name');
+is(@data, 1, 'One value between 0 and 100');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.level<100 && @.level>=0)].name');
+is(@data, 1, 'One value between 100 and 0');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.level>=0 && @.level<1000)].name');
+is(@data, 2, 'Two values between 0 and 1000');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.level<1000 && @.level>=0)].name');
+is(@data, 2, 'Two values between 1000 and 0');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.level>=0 && @.name=="Marketing" && @.level<100)].name');
+is(@data, 1, 'Got Marketing');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.level>=0 && @.name=="Marketing" && @.level<50)].name');
+is(@data, 0, 'No Marketing');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.level>=0 && @.name=="Marketong" && @.level<100)].name');
+is(@data, 0, 'No Marketong');
+
+## OR test
+@data = evaluate_jsonpath($json, '$.Competency[?(@.level>0 || @.level>1000)].name');
+is(@data, 2, 'All values are more than zero OR more than 1000');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.level>1000 || @.level>0)].name');
+is(@data, 2, 'The other way around');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.level>1000 || @.level>500)].name');
+is(@data, 0, 'No value greater than 1000 or 500');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.level>1000 || @.level>200)].name');
+is(@data, 1, 'One value greater than 1000 or 200');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.level>1000 || @.level>200 || @.level>50)].name');
+is(@data, 2, 'Two values greater than 1000 or 200 or 50');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.level>1000 || @.level>200 || @.name=="Marketing")].name');
+is(@data, 2, 'One value greater than 1000 or 200 and one Marketing');
+
+## Mix AND and OR
+@data = evaluate_jsonpath($json, '$.Competency[?(@.level==75 && @.name=="Marketing" || @.level==500 && @.name="Something Else")].name');
+is(@data, 2, 'Got "Marketing" and "Something Else"');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.level==500 && @.name=="Marketing" || @.level==75 && @.name="Something Else")].name');
+is(@data, 0, 'Got Nothing');
+
+SKIP: {
+    skip "Not working on AND/OR naive and quick implementation";
+    @data = evaluate_jsonpath($json, '$.Competency[?(@.level>1000 || @.level>200 || @.name!="Ben && Jerry")].name');
+    is(@data, 2, 'Data containing "&&" might break things');
+
+    @data = evaluate_jsonpath($json, '$.Competency[?(@.name!="Ben || Jerry" && @.level>1000)].name');
+    is(@data, 0, 'Data containing "||" might break things');
+
+
+    @data = evaluate_jsonpath($json, '$.Competency[?(@.level==75 && ( @.name=="Marketing" || @.name="Something Else" ) && @.level==500)].name');
+    is(@data, 0, 'Brackets not working as expected');
+
+    @data = evaluate_jsonpath($json, '$.Competency[?(( @.name=="Marketing" || @.name="Something Else" ) && @.level==500)].name');
+    is(@data, 1, 'Brackets not working as expected');
+
+    @data = evaluate_jsonpath($json, '$.Competency[?(@.level==75 && ( @.name=="Marketing" || @.name="Something Else" ))].name');
+    is(@data, 1, 'Brackets not working as expected');
+};
+
+done_testing();


### PR DESCRIPTION
This should add some basic  `&&` and `||` within the filter. Not perfect (see `t/filter_expression_and_or.t:81`) but works for me :)

I am bit confused because the module version in GitHub is 0.420 while CPAN has 0.431... Hence not sure I branched out from the right place.

