### PR TITLE
Replace remaining use of JSON with JSON::MaybeXS

### DIFF
--- a/t/01basic.t
+++ b/t/01basic.t
@@ -22,8 +22,8 @@ terms as Perl itself.
 use Test::More;
 BEGIN { use_ok('JSON::Path') }
 
-use JSON;
-my $object = from_json(<<'JSON');
+use JSON::MaybeXS;
+my $object = decode_json(<<'JSON');
 {
 	"store": {
 		"book": [

--- a/t/02zeroth.t
+++ b/t/02zeroth.t
@@ -24,7 +24,7 @@ terms as Perl itself.
 use Test::More tests => 6;
 BEGIN { use_ok('JSON::Path') }
 
-use JSON;
+use JSON::MaybeXS;
 my $object = {    #
     'foo' => [    #
         { 'bar' => 1, },
@@ -34,18 +34,18 @@ my $object = {    #
 };
 
 my $jpath1  = JSON::Path->new('$.foo[0]');
-my @values1 = $jpath1->values( to_json($object) );
+my @values1 = $jpath1->values( encode_json($object) );
 is( scalar @values1, 1, 'Only returned a single result.' );
 
 my $jpath2  = JSON::Path->new('$.foo[0,1]');
-my @values2 = $jpath2->values( to_json($object) );
+my @values2 = $jpath2->values( encode_json($object) );
 is( scalar @values2, 2, 'Returned two results.' );
 
 my $jpath3  = JSON::Path->new('$.foo[1:3]');
-my @values3 = $jpath3->values( to_json($object) );
+my @values3 = $jpath3->values( encode_json($object) );
 is( scalar @values3, 2, 'Returned two results.' );
 
 my $jpath4  = JSON::Path->new('$.foo[-1:]');
-my @values4 = $jpath4->values( to_json($object) );
+my @values4 = $jpath4->values( encode_json($object) );
 is( scalar @values4,    1, 'Returned one result.' );
 is( $values4[0]->{bar}, 3, 'Correct result.' );

--- a/t/03shortcuts.t
+++ b/t/03shortcuts.t
@@ -20,8 +20,8 @@ terms as Perl itself.
 use Test::More;
 use JSON::Path -all;
 
-use JSON;
-my $object = from_json(<<'JSON');
+use JSON::MaybeXS;
+my $object = decode_json(<<'JSON');
 {
 	"store": {
 		"book": [

--- a/t/04map.t
+++ b/t/04map.t
@@ -20,8 +20,8 @@ terms as Perl itself.
 use Test::More;
 use JSON::Path -all;
 
-use JSON;
-my $object = from_json(<<'JSON');
+use JSON::MaybeXS;
+my $object = decode_json(<<'JSON');
 {
 	"store": {
 		"book": [

--- a/t/05set.t
+++ b/t/05set.t
@@ -26,8 +26,8 @@ use warnings;
 use Test::More;
 use JSON::Path -all;
 
-use JSON;
-my $object = from_json(<<'JSON');
+use JSON::MaybeXS;
+my $object = decode_json(<<'JSON');
 {
 	"store": {
 		"book": [

--- a/t/08context.t
+++ b/t/08context.t
@@ -1,8 +1,8 @@
 use Test::More;
 use JSON::Path;
-use JSON;
+use JSON::MaybeXS;
 
-my $object = from_json(<<'JSON');
+my $object = decode_json(<<'JSON');
 {
     "elements": [
         { "id": 1 },


### PR DESCRIPTION
We already use JSON::MaybeXS in lib and in a few tests, this switches to it for the remaining tests thus dropping a prerequisite for install.