### PR TITLE
Replace Exporter{,::Easy,::Tiny} with Exporter::Shiny

### DIFF
--- a/lib/JSON/Path.pm
+++ b/lib/JSON/Path.pm
@@ -6,8 +6,7 @@ package JSON::Path;
 
 # VERSION
 
-use Exporter::Tiny ();
-our @ISA       = qw/ Exporter::Tiny /;
+use Exporter::Shiny qw/ jpath jpath1 jpath_map /;
 our $AUTHORITY = 'cpan:POPEFELIX';
 our $Safe      = 1;
 
@@ -16,8 +15,6 @@ use JSON::MaybeXS qw/decode_json/;
 use JSON::Path::Evaluator;
 use Scalar::Util qw[blessed];
 use LV ();
-
-our @EXPORT_OK = qw/ jpath jpath1 jpath_map /;
 
 use overload '""' => \&to_string;
 

--- a/lib/JSON/Path/Constants.pm
+++ b/lib/JSON/Path/Constants.pm
@@ -10,29 +10,29 @@ package JSON::Path::Constants;
 
 use Readonly;
 
-use Exporter::Easy (
-    TAGS => [
-        symbols => [
-            '$DOLLAR_SIGN',          '$COMMERCIAL_AT',     '$FULL_STOP',      '$LEFT_SQUARE_BRACKET',
-            '$RIGHT_SQUARE_BRACKET', '$ASTERISK',          '$COLON',          '$LEFT_PARENTHESIS',
-            '$RIGHT_PARENTHESIS',    '$COMMA',             '$QUESTION_MARK',  '$EQUAL_SIGN',
-            '$EXCLAMATION_MARK',     '$GREATER_THAN_SIGN', '$LESS_THAN_SIGN', '$QUOTATION_MARK',
-            '$APOSTROPHE'
-        ],
-        operators => [
-            '$TOKEN_ROOT',           '$TOKEN_CURRENT',
-            '$TOKEN_CHILD',          '$TOKEN_RECURSIVE',
-            '$TOKEN_ALL',            '$TOKEN_FILTER_OPEN',
-            '$TOKEN_SCRIPT_OPEN',    '$TOKEN_FILTER_SCRIPT_CLOSE',
-            '$TOKEN_SUBSCRIPT_OPEN', '$TOKEN_SUBSCRIPT_CLOSE',
-            '$TOKEN_UNION',          '$TOKEN_ARRAY_SLICE',
-            '$TOKEN_SINGLE_EQUAL',   '$TOKEN_DOUBLE_EQUAL',
-            '$TOKEN_TRIPLE_EQUAL',   '$TOKEN_GREATER_THAN',
-            '$TOKEN_LESS_THAN',      '$TOKEN_NOT_EQUAL',
-            '$TOKEN_GREATER_EQUAL',  '$TOKEN_LESS_EQUAL',
-        ],
-    ]
+use Exporter::Shiny;
+our %EXPORT_TAGS = (
+    symbols => [
+        '$DOLLAR_SIGN',          '$COMMERCIAL_AT',     '$FULL_STOP',      '$LEFT_SQUARE_BRACKET',
+        '$RIGHT_SQUARE_BRACKET', '$ASTERISK',          '$COLON',          '$LEFT_PARENTHESIS',
+        '$RIGHT_PARENTHESIS',    '$COMMA',             '$QUESTION_MARK',  '$EQUAL_SIGN',
+        '$EXCLAMATION_MARK',     '$GREATER_THAN_SIGN', '$LESS_THAN_SIGN', '$QUOTATION_MARK',
+        '$APOSTROPHE'
+    ],
+    operators => [
+        '$TOKEN_ROOT',           '$TOKEN_CURRENT',
+        '$TOKEN_CHILD',          '$TOKEN_RECURSIVE',
+        '$TOKEN_ALL',            '$TOKEN_FILTER_OPEN',
+        '$TOKEN_SCRIPT_OPEN',    '$TOKEN_FILTER_SCRIPT_CLOSE',
+        '$TOKEN_SUBSCRIPT_OPEN', '$TOKEN_SUBSCRIPT_CLOSE',
+        '$TOKEN_UNION',          '$TOKEN_ARRAY_SLICE',
+        '$TOKEN_SINGLE_EQUAL',   '$TOKEN_DOUBLE_EQUAL',
+        '$TOKEN_TRIPLE_EQUAL',   '$TOKEN_GREATER_THAN',
+        '$TOKEN_LESS_THAN',      '$TOKEN_NOT_EQUAL',
+        '$TOKEN_GREATER_EQUAL',  '$TOKEN_LESS_EQUAL',
+    ],
 );
+our @EXPORT_OK = map @$_, values %EXPORT_TAGS;
 
 Readonly our $QUOTATION_MARK       => q{"};
 Readonly our $APOSTROPHE           => q{'};

--- a/lib/JSON/Path/Evaluator.pm
+++ b/lib/JSON/Path/Evaluator.pm
@@ -8,7 +8,6 @@ use 5.008;
 
 use Carp;
 use Carp::Assert qw(assert);
-use Exporter::Tiny ();
 use JSON::MaybeXS;
 use JSON::Path::Constants qw(:operators :symbols);
 use JSON::Path::Tokenizer qw(tokenize);
@@ -21,9 +20,8 @@ use Sys::Hostname qw/hostname/;
 use Try::Tiny;
 
 # VERSION
-use base q(Exporter);
+use Exporter::Shiny qw/evaluate_jsonpath/;
 our $AUTHORITY = 'cpan:POPEFELIX';
-our @EXPORT_OK = qw/ evaluate_jsonpath /;
 
 Readonly my $OPERATOR_IS_TRUE         => 'IS_TRUE';
 Readonly my $OPERATOR_TYPE_PATH       => 1;
@@ -902,4 +900,3 @@ instead.
 =end :list
 
 =cut
-

--- a/lib/JSON/Path/Tokenizer.pm
+++ b/lib/JSON/Path/Tokenizer.pm
@@ -7,7 +7,7 @@ use 5.008;
 use Carp;
 use Readonly;
 use JSON::Path::Constants qw(:symbols :operators);
-use Exporter::Easy ( OK => ['tokenize'] );
+use Exporter::Shiny 'tokenize';
 
 Readonly my $ESCAPE_CHAR      => qq{\\};
 Readonly my %OPERATORS => (


### PR DESCRIPTION
Exporter::Shiny is part of the Exporter::Tiny dist so we're just dropping Exporter and Exporter::Easy as superfluous deps.

This'll also drop base as dep :tada: 