### PR TITLE
Remove unused Sys::Hostname dep

### DIFF
--- a/lib/JSON/Path/Evaluator.pm
+++ b/lib/JSON/Path/Evaluator.pm
@@ -17,7 +17,6 @@ use Readonly;
 use Safe;
 use Scalar::Util qw/looks_like_number blessed refaddr/;
 use Storable qw/dclone/;
-use Sys::Hostname qw/hostname/;
 use Try::Tiny;
 
 # VERSION


### PR DESCRIPTION
Its last use was removed in 09fca4e in 2016, looks like we used to enable asserts automatically if the hostname was `/^lls.+?[.]cb[.]careerbuilder[.]com/`