### PR TITLE
Replace Test::{Deep,More,Most} with Test2::V0 in t/

### DIFF
--- a/t/01basic.t
+++ b/t/01basic.t
@@ -19,8 +19,7 @@ terms as Perl itself.
 
 =cut
 
-use Test::More;
-BEGIN { use_ok('JSON::Path') }
+use Test2::V0 '-target' => 'JSON::Path';
 
 use JSON::MaybeXS;
 my $object = decode_json(<<'JSON');

--- a/t/02zeroth.t
+++ b/t/02zeroth.t
@@ -21,8 +21,7 @@ terms as Perl itself.
 
 =cut
 
-use Test::More tests => 6;
-BEGIN { use_ok('JSON::Path') }
+use Test2::V0 '-target' => 'JSON::Path';
 
 use JSON::MaybeXS;
 my $object = {    #
@@ -49,3 +48,5 @@ my $jpath4  = JSON::Path->new('$.foo[-1:]');
 my @values4 = $jpath4->values( encode_json($object) );
 is( scalar @values4,    1, 'Returned one result.' );
 is( $values4[0]->{bar}, 3, 'Correct result.' );
+
+done_testing;

--- a/t/03shortcuts.t
+++ b/t/03shortcuts.t
@@ -17,7 +17,7 @@ terms as Perl itself.
 
 =cut
 
-use Test::More;
+use Test2::V0;
 use JSON::Path -all;
 
 use JSON::MaybeXS;
@@ -62,9 +62,9 @@ JSON
 
 my $path1 = '$.store.book[*].title';
 
-is_deeply( [ jpath1( $object, $path1 ) ], ['Sayings of the Century'], );
+is( [ jpath1( $object, $path1 ) ], ['Sayings of the Century'], );
 
-is_deeply(
+is(
     [ jpath( $object, $path1 ) ],
     [ 'Sayings of the Century', 'Sword of Honour', 'Moby Dick', 'The Lord of the Rings' ],
 );

--- a/t/04map.t
+++ b/t/04map.t
@@ -17,7 +17,7 @@ terms as Perl itself.
 
 =cut
 
-use Test::More;
+use Test2::V0;
 use JSON::Path -all;
 
 use JSON::MaybeXS;
@@ -65,15 +65,15 @@ my $path1 = '$.store.book[*].title';
 
 jpath_map { uc $_ } $object, '$.store.book[*].title';
 
-is_deeply( [ jpath1( $object, $path1 ) ], [ map uc, 'Sayings of the Century' ], );
+is( [ jpath1( $object, $path1 ) ], [ map uc, 'Sayings of the Century' ], );
 
-is_deeply(
+is(
     [ jpath( $object, $path1 ) ],
     [ map uc, 'Sayings of the Century', 'Sword of Honour', 'Moby Dick', 'The Lord of the Rings' ],
 );
 
 is( JSON::Path->new('$.store.book[*].author')->set( $object => 'Anon', 2 ), 2, );
 
-is_deeply( [ jpath( $object, '$.store.book[*].author' ) ], [ 'Anon', 'Anon', 'Herman Melville', 'J. R. R. Tolkien' ], );
+is( [ jpath( $object, '$.store.book[*].author' ) ], [ 'Anon', 'Anon', 'Herman Melville', 'J. R. R. Tolkien' ], );
 
 done_testing();

--- a/t/05set.t
+++ b/t/05set.t
@@ -21,9 +21,7 @@ terms as Perl itself.
 
 =cut
 
-use strict;
-use warnings;
-use Test::More;
+use Test2::V0;
 use JSON::Path -all;
 
 use JSON::MaybeXS;
@@ -69,12 +67,12 @@ JSON
 my $titles = '$.store.book[*].title';
 my $jpath  = JSON::Path->new($titles);
 
-is_deeply( [ $jpath->values($object) ],
+is( [ $jpath->values($object) ],
     [ "Sayings of the Century", "Sword of Honour", "Moby Dick", "The Lord of the Rings", ] );
 
 is( $jpath->set( $object => 'TBD', 2 ), 2, );
 
-is_deeply( [ $jpath->values($object) ], [ "TBD", "TBD", "Moby Dick", "The Lord of the Rings", ], );
+is( [ $jpath->values($object) ], [ "TBD", "TBD", "Moby Dick", "The Lord of the Rings", ], );
 
 my $author = '$.store.book[2].author';
 $jpath = JSON::Path->new($author);

--- a/t/06lvalue.t
+++ b/t/06lvalue.t
@@ -17,9 +17,7 @@ terms as Perl itself.
 
 =cut
 
-use strict;
-use warnings;
-use Test::More;
+use Test2::V0;
 
 use JSON::Path -all;
 
@@ -27,12 +25,12 @@ my $person = { name => "Robert", foo => { bar => [ 1, 2, 3 ] } };
 my $path = JSON::Path->new('$.name');
 $path->value($person) = "Bob";
 
-is_deeply( $person, { name => "Bob", foo => { bar => [ 1, 2, 3 ] } } , q{Setting 'name' changes only the 'name' key and nothing else});
+is( $person, { name => "Bob", foo => { bar => [ 1, 2, 3 ] } } , q{Setting 'name' changes only the 'name' key and nothing else});
 
 jpath1( $person, '$.name' )    = "Robbie";
 jpath1( $person, '$.foo.bar' ) = 12;
 
-is_deeply( $person, { name => "Robbie", foo => { bar => 12 } }, q{jpath1() works as lvalue});
+is( $person, { name => "Robbie", foo => { bar => 12 } }, q{jpath1() works as lvalue});
 $path->value($person) ||= 'Fred';
 is $person->{name}, 'Robbie', q{lvalue works with ||=};
 
@@ -45,4 +43,3 @@ $path->value($person) ||= 'beta';
 is $person->{quuy}, 'beta', q{lvalue and ||= will create keys not previously extant};
 
 done_testing;
-

--- a/t/07utf8.t
+++ b/t/07utf8.t
@@ -17,8 +17,7 @@ terms as Perl itself.
 
 =cut
 
-use Test::More tests => 5;
-BEGIN { use_ok('JSON::Path') }
+use Test2::V0 '-target' => 'JSON::Path';
 
 use JSON::MaybeXS;
 my $data = <<"JSON";
@@ -62,3 +61,4 @@ my $path2    = JSON::Path->new('$.store.book[1].author');
 my @results2 = $path2->values($object);
 is( $results2[0], "\x{61}\x{0300}\x{0320}. u. thor", "basic value result" );
 
+done_testing;

--- a/t/08context.t
+++ b/t/08context.t
@@ -1,5 +1,4 @@
-use Test::More;
-use JSON::Path;
+use Test2::V0 '-target' => 'JSON::Path';
 use JSON::MaybeXS;
 
 my $object = decode_json(<<'JSON');
@@ -14,7 +13,7 @@ JSON
 
 my $path1 = JSON::Path->new('$.elements[*]');
 my @arr   = $path1->values($object);
-is_deeply \@arr, [ { id => 1 }, { id => 2 } ], 'multiple values in list context';
+is \@arr, [ { id => 1 }, { id => 2 } ], 'multiple values in list context';
 my $scal = $path1->values($object);
 cmp_ok $scal, '==', 2, 'multiple values in scalar context';
 

--- a/t/dots_in_path.t
+++ b/t/dots_in_path.t
@@ -1,4 +1,3 @@
-use 5.016;
 use Test2::V0 '-target' => 'JSON::Path';
 
 my $json = '{

--- a/t/evaluator/paths.t
+++ b/t/evaluator/paths.t
@@ -1,5 +1,4 @@
-use Test::Most;
-use Test::Deep;
+use Test2::V0;
 use JSON::MaybeXS qw/encode_json decode_json/;
 use JSON::Path::Evaluator;
 use Storable qw(dclone);
@@ -77,13 +76,14 @@ sub do_test {
     my @expressions = @_;
     while ( my $expression = shift @expressions ) {
         my $expected = shift @expressions;
-        my @got;
-        lives_and {
-            @got = JSON::Path::Evaluator::evaluate_jsonpath( $json, $expression );
-            cmp_bag( \@got, $expected );
-        }
-        qq{"$expression" evaluated correctly};
+        subtest $expression => sub {
+            my @got;
+            ok lives {
+                @got = JSON::Path::Evaluator::evaluate_jsonpath( $json, $expression );
+            }, 'lives';
 
+            is \@got, bag { item $_ for @$expected; end }, 'evaluated correctly';
+        };
     }
 }
 

--- a/t/evaluator/refs.t
+++ b/t/evaluator/refs.t
@@ -1,6 +1,5 @@
-use Test::Most;
+use Test2::V0 '-target' => 'JSON::Path::Evaluator';
 use Carp;
-use JSON::Path::Evaluator;
 use JSON::MaybeXS qw/decode_json/;
 
 no warnings qw/uninitialized/;
@@ -144,7 +143,7 @@ sub do_test {
 
     subtest $expression => sub {
         my @refs;
-        lives_ok { @refs = JSON::Path::Evaluator::evaluate_jsonpath( $obj, $expression, want_ref => 1 ) }
+        ok lives { @refs = JSON::Path::Evaluator::evaluate_jsonpath( $obj, $expression, want_ref => 1 ) },
         q{evaluate() did not die};
         $test->( \@refs, $obj );
     };
@@ -300,4 +299,3 @@ sub sample_json {
 END
     return $data;
 }
-

--- a/t/filter_expression_and_or.t
+++ b/t/filter_expression_and_or.t
@@ -5,7 +5,7 @@ within the filter part of the path.
 
 =cut
 
-use Test::More;
+use Test2::V0;
 use JSON::Path::Evaluator qw/evaluate_jsonpath/;
 
 my $json = q@{

--- a/t/hashref_not_modified.t
+++ b/t/hashref_not_modified.t
@@ -1,5 +1,4 @@
-use Test::Most;
-use JSON::Path;
+use Test2::V0 '-target' => 'JSON::Path';
 
 # Test demonstrating RT 122493, "Changed behavior - get() returns an array with a single, undef element when no results are found"
 # https://rt.cpan.org/Ticket/Display.html?id=122493
@@ -9,6 +8,6 @@ my $p = JSON::Path->new("\$foo");
 
 my $res = $p->get($orig);
 
-is_deeply ( $orig, { bar => 1 }, "hashref is unchanged");
+is( $orig, { bar => 1 }, "hashref is unchanged");
 
 done_testing();


### PR DESCRIPTION
We were already using it in a couple of tests so this just makes it consistent and reduces the deps needed to install this dist.

Also drop a `use 5.016` from a test, this is the highest use VERSION in this dist and was causing dzil to set it as the minimum. I'm not sure what the actual minimum Perl version is for this dist but I don't think it should be implicitly set from one test file.

xt/ is left alone for now as it doesn't affect end users.