### PR TITLE
Add GItHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: Test
+
+on:
+  pull_request:
+    branches:
+      - master
+
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: ${{ matrix.perl }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        perl: [
+          '5.10', '5.12', '5.14', '5.16', '5.18', '5.20', '5.22', '5.24',
+          '5.26', '5.28', '5.30', '5.32', '5.34'
+        ]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl }}
+
+      - run: perl -v
+
+      - run: cpanm --cpanfile cpanfile --installdeps --notest .
+
+      - run: prove -l

--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,12 @@
+requires 'Carp::Assert';
+requires 'Exporter::Tiny';
+requires 'JSON::MaybeXS';
+requires 'LV';
+requires 'List::Util' => '1.45';    # For uniq.
+requires 'Readonly';
+requires 'Try::Tiny';
+requires 'perl' => '5.010';
+
+on test => sub {
+    requires 'Test2::V0';
+};

--- a/dist.ini
+++ b/dist.ini
@@ -6,9 +6,7 @@ copyright_year   = 2022
 
 ; authordep Pod::Elemental::Transformer::List
 version = 0.51
-[AutoPrereqs]
-[Prereqs]
-List::Util = 1.48
+[Prereqs::FromCPANfile]
 [@Basic]
 [MetaJSON]
 [GithubMeta]
@@ -27,4 +25,3 @@ filename = README.md
 ;allow_dirty = META.json
 ;allow_dirty = README.md
 ;build_warnings = 1
-

--- a/lib/JSON/Path.pm
+++ b/lib/JSON/Path.pm
@@ -1,8 +1,7 @@
-use 5.008;
+package JSON::Path;
+
 use strict;
 use warnings;
-
-package JSON::Path;
 
 # VERSION
 

--- a/lib/JSON/Path/Constants.pm
+++ b/lib/JSON/Path/Constants.pm
@@ -1,8 +1,7 @@
+package JSON::Path::Constants;
+
 use strict;
 use warnings;
-use 5.008;
-
-package JSON::Path::Constants;
 
 # ABSTRACT: Constants used in the JSON::Path distribution
 

--- a/lib/JSON/Path/Evaluator.pm
+++ b/lib/JSON/Path/Evaluator.pm
@@ -2,7 +2,6 @@ package JSON::Path::Evaluator;
 
 use strict;
 use warnings;
-use 5.008;
 
 # ABSTRACT: A module that recursively evaluates JSONPath expressions with native support for Javascript-style filters
 
@@ -213,8 +212,8 @@ sub evaluate {
 sub _reftable_walker {
     my ( $self, $json_object, $base_path ) = @_;
 
-    $base_path   = defined $base_path   ? $base_path   : '$';
-    $json_object = defined $json_object ? $json_object : $self->root;
+    $base_path   //= '$';
+    $json_object //= $self->root;
 
     my @entries = ( refaddr $json_object => $base_path );
 
@@ -248,7 +247,7 @@ sub _evaluate {    # This assumes that the token stream is syntactically valid
 
     return unless ref $obj;
 
-    $token_stream = defined $token_stream ? $token_stream : [];
+    $token_stream //= [];
 
     while ( defined( my $token = shift @{$token_stream} ) ) {
         next if $token eq $TOKEN_CURRENT;

--- a/lib/JSON/Path/Tokenizer.pm
+++ b/lib/JSON/Path/Tokenizer.pm
@@ -2,7 +2,6 @@ package JSON::Path::Tokenizer;
 
 use strict;
 use warnings;
-use 5.008;
 
 use Carp;
 use Readonly;

--- a/t/evaluator/refs.t
+++ b/t/evaluator/refs.t
@@ -2,9 +2,7 @@ use Test2::V0 '-target' => 'JSON::Path::Evaluator';
 use Carp;
 use JSON::MaybeXS qw/decode_json/;
 
-no warnings qw/uninitialized/;
-my @tests_to_run = split /,/, $ARGV[0];
-use warnings qw/uninitialized/;
+my @tests_to_run = split /,/, $ARGV[0] // '';
 
 subtest recursive => sub {
     plan skip_all => 'This test not requested' if @tests_to_run && !grep { lc($_) eq 'recursive' } @tests_to_run;


### PR DESCRIPTION
Making this a draft PR for now as it depends on the other two PRs being merged and there's some unanswered questions.

Committed a cpanfile and make the dzil file use that as the source of deps, this seems to be the best way to avoid needing to install dzil in the CI each and every time.

 - Set the minimum Perl to 5.10 rather than the 5.8 which was implied in the pms since we do in fact already use defined-or, so use it in another place while we're at it. This is still technically lower than the 5.16 we advertise on the latest CPAN release which was due to a superfluous explicit `use 5.016` in a test which is removed in #25
- Made the xt tests not require passing, we might want to re-consider this and some of the tests, especially the one that requires we use tabs, none of the source seems to be indented with tabs.
- Consider bumping even higher than 5.10 to make use of more Perl features? 5.10 is a pretty common minimum version though, one of the big three according to https://cpan.rocks