### PR TITLE
Add regular expressions to filters

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,19 @@
 {{$NEXT}}
 
     [ Bug Fixes ]
+    - Fix unicode issue in POD
+    David Escribano García++
+
+    - Fix use of quotes and escaped characters inside quoted text
+    David Escribano García++
+
+    [ Other ]
+    - Implement =~ operator to filter using regular expressions.
+    David Escribano García++
+
+1.0.2     2022-09-06 10:13:31-05:00 America/Chicago
+
+    [ Bug Fixes ]
     - Fix missing dependencies
 
 1.0.1     2022-08-30 21:58:38-05:00 America/Chicago

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ JSON::Path
 
 # VERSION
 
-version 1.0.1
+version 1.0.3
 
 # SYNOPSIS
 
@@ -209,6 +209,10 @@ Specification: [http://goessner.net/articles/JsonPath/](http://goessner.net/arti
 
 Implementations in PHP, Javascript and C#:
 [http://code.google.com/p/jsonpath/](http://code.google.com/p/jsonpath/).
+
+Jayway JsonPath:
+[https://github.com/json-path/JsonPath](https://github.com/json-path/JsonPath).
+
 
 Related modules: [JSON](https://metacpan.org/pod/JSON), [JSON::JOM](https://metacpan.org/pod/JSON%3A%3AJOM), [JSON::T](https://metacpan.org/pod/JSON%3A%3AT), [JSON::GRDDL](https://metacpan.org/pod/JSON%3A%3AGRDDL),
 [JSON::Hyper](https://metacpan.org/pod/JSON%3A%3AHyper), [JSON::Schema](https://metacpan.org/pod/JSON%3A%3ASchema).

--- a/dist.ini
+++ b/dist.ini
@@ -5,7 +5,7 @@ copyright_holder = Kit Peters
 copyright_year   = 2022
 
 ; authordep Pod::Elemental::Transformer::List
-version = 1.0.2
+version = 1.0.3
 [Prereqs::FromCPANfile]
 [@Basic]
 [MetaJSON]

--- a/lib/JSON/Path.pm
+++ b/lib/JSON/Path.pm
@@ -124,6 +124,8 @@ sub map {
 
 __END__
 
+=encoding utf-8
+
 =head1 NAME
 
 JSON::Path - search nested hashref/arrayref structures using JSONPath
@@ -132,7 +134,7 @@ JSON::Path - search nested hashref/arrayref structures using JSONPath
 
  my $data = {
   "store" => {
-    "book" => [ 
+    "book" => [
       { "category" =>  "reference",
         "author"   =>  "Nigel Rees",
         "title"    =>  "Sayings of the Century",
@@ -163,17 +165,17 @@ JSON::Path - search nested hashref/arrayref structures using JSONPath
     ],
   },
  };
- 
+
  use JSON::Path 'jpath_map';
 
  # All books in the store
  my $jpath   = JSON::Path->new('$.store.book[*]');
  my @books   = $jpath->values($data);
- 
+
  # The author of the last (by order) book
  my $jpath   = JSON::Path->new('$..book[-1:].author');
  my $tolkien = $jpath->value($data);
- 
+
  # Convert all authors to uppercase
  jpath_map { uc $_ } $data, '$.store.book[*].author';
 
@@ -235,7 +237,7 @@ the first result.
 =item C<<  set($object, $value, $limit)  >>
 
 Alters C<< $object >>, setting the paths to C<< $value >>. If set, then
-C<< $limit >> limits the number of changes made. 
+C<< $limit >> limits the number of changes made.
 
 TAKE NOTE! This will create keys in $object. E.G.:
 
@@ -283,7 +285,7 @@ Like C<value>, it can be used as an lvalue.
 
 =item C<< jpath_map { CODE } $object, $path_string >>
 
-Shortcut for C<< JSON::Path->new($path_string)->map($object, $code) >>. 
+Shortcut for C<< JSON::Path->new($path_string)->map($object, $code) >>.
 
 =back
 
@@ -364,7 +366,7 @@ Kit Peters E<lt>popefelix@cpan.orgE<gt>
 
 =head1 CONTRIBUTORS
 
-Szymon Nieznański E<lt>s.nez@member.fsf.orgE<gt> 
+Szymon Nieznański E<lt>s.nez@member.fsf.orgE<gt>
 
 Kit Peters E<lt>popefelix@cpan.orgE<gt>
 

--- a/lib/JSON/Path/Constants.pm
+++ b/lib/JSON/Path/Constants.pm
@@ -16,7 +16,7 @@ our %EXPORT_TAGS = (
         '$RIGHT_SQUARE_BRACKET', '$ASTERISK',          '$COLON',          '$LEFT_PARENTHESIS',
         '$RIGHT_PARENTHESIS',    '$COMMA',             '$QUESTION_MARK',  '$EQUAL_SIGN',
         '$EXCLAMATION_MARK',     '$GREATER_THAN_SIGN', '$LESS_THAN_SIGN', '$QUOTATION_MARK',
-        '$APOSTROPHE'
+        '$APOSTROPHE',           '$TILDE_SIGN'
     ],
     operators => [
         '$TOKEN_ROOT',           '$TOKEN_CURRENT',
@@ -29,7 +29,7 @@ our %EXPORT_TAGS = (
         '$TOKEN_TRIPLE_EQUAL',   '$TOKEN_GREATER_THAN',
         '$TOKEN_LESS_THAN',      '$TOKEN_NOT_EQUAL',
         '$TOKEN_GREATER_EQUAL',  '$TOKEN_LESS_EQUAL',
-        '$TOKEN_QUOTE'
+        '$TOKEN_QUOTE',          '$TOKEN_REGEX',
     ],
 );
 our @EXPORT_OK = map @$_, values %EXPORT_TAGS;
@@ -51,6 +51,7 @@ Readonly our $EQUAL_SIGN           => '=';
 Readonly our $EXCLAMATION_MARK     => '!';
 Readonly our $GREATER_THAN_SIGN    => '>';
 Readonly our $LESS_THAN_SIGN       => '<';
+Readonly our $TILDE_SIGN           => '~';
 
 Readonly our $TOKEN_ROOT                => $DOLLAR_SIGN;
 Readonly our $TOKEN_CURRENT             => $COMMERCIAL_AT;
@@ -73,6 +74,7 @@ Readonly our $TOKEN_NOT_EQUAL           => $EXCLAMATION_MARK . $EQUAL_SIGN;
 Readonly our $TOKEN_GREATER_EQUAL       => $GREATER_THAN_SIGN . $EQUAL_SIGN;
 Readonly our $TOKEN_LESS_EQUAL          => $LESS_THAN_SIGN . $EQUAL_SIGN;
 Readonly our $TOKEN_QUOTE               => $QUOTATION_MARK;
+Readonly our $TOKEN_REGEX               => $EQUAL_SIGN . $TILDE_SIGN;
 
 1;
 __END__

--- a/lib/JSON/Path/Tokenizer.pm
+++ b/lib/JSON/Path/Tokenizer.pm
@@ -48,22 +48,67 @@ sub tokenize {
 sub _read_to_filter_script_close {
     my $chars = shift;
 
+    my %escaped_chars = (
+        "b"  => "\x{0008}",
+        "f"  => "\x{000C}",
+        "n"  => "\x{000A}",
+        "r"  => "\x{000D}",
+        "t"  => "\x{0009}",
+        "v"  => "\x{000B}",
+        "0"  => "\x{0000}",
+        "'"  => "\x{0027}",
+        '"'  => "\x{0022}",
+        "\\" => "\x{005C}",
+    );
+
     #print "$invocation: read to filter script close: " . join( '', @{$chars} ) . "\n";
     my $filter;
+    my $in_regex;
     my $in_quote;
+    my $escape = 0;
+
+    my @quote_chars = ($APOSTROPHE, $QUOTATION_MARK);
+    my @regex_chars = "/";
+
     while ( defined( my $char = shift @{$chars} ) ) {
-        $filter .= $char;
-        if ( $char eq $APOSTROPHE || $char eq $QUOTATION_MARK ) {
-            if ( $in_quote && $in_quote eq $char ) {
+        if ( $in_quote ) {
+            if ( $escape ) {
+                ## Replace \t by tab, \\ by \, etc
+                $char = $escaped_chars{$char} || $char;
+                $escape = 0;
+            }
+            elsif ( $char eq "\\" ) {
+                ## Don't include \ and flag so next char in sequence
+                ## is replaced correctly.
+                $escape = 1;
+                next;
+            }
+            elsif ( $char eq $in_quote ) {
                 $in_quote = '';
             }
-            else {
-                $in_quote = $char;
+        }
+        elsif ( $in_regex ) {
+            if ( $escape ) {
+                $escape = 0;
+            }
+            elsif ( $char eq "\\" ) {
+                $escape = 1;
+            }
+            elsif ( $char eq $in_regex ) {
+                $in_regex = '';
             }
         }
+        elsif (grep { $_ eq $char } @quote_chars) {
+            $in_quote = $char;
+        }
+        elsif (grep { $_ eq $char } @regex_chars) {
+            $in_regex = $char;
+        }
+
+        $filter .= $char;
 
         last unless @{$chars};
-        last if $chars->[0] eq $RIGHT_PARENTHESIS && !$in_quote;
+        last if $chars->[0] eq $RIGHT_PARENTHESIS && !$in_quote && !$in_regex;
     }
     return $filter;
 }

--- a/t/filter_expression_regex.t
+++ b/t/filter_expression_regex.t
@@ -1,0 +1,83 @@
+=head1 PURPOSE
+
+Test expressions that use regexes
+within the filter part of the path.
+
+=cut
+
+use Test2::V0;
+use JSON::Path::Evaluator qw/evaluate_jsonpath/;
+
+my $json = q@{
+    "Competency" : [
+        {
+            "level" : 75,
+            "name" : "Marketing"
+        },
+        {
+            "level" : 100,
+            "name" : "Market Analysis"
+        },
+        {
+            "level" : 500,
+            "name" : "[Something] ('/Else/') \"\@-3/2\\\\8/\""
+        }
+    ]
+}@;
+
+my @data;
+@data = evaluate_jsonpath($json, '$.Competency[?(@.name =~ /Market/)]');
+is(@data, 2, 'Regex work. /Market/');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.name =~ /market/)]');
+is(@data, 0, 'Nothing found, wrong case. /market/');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.name =~ /market/i)]');
+is(@data, 2, 'Regex with i modifier works. /market/i');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.name =~ /^market$/)]');
+is(@data, 0, 'Regex with ^ and $ works. /^market$/');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.name =~ /market/i && @.level > 80 )]');
+is(@data, 1, 'Regex works combined with other clausules (and)');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.level > 100 || @.name =~ /market/i)]');
+is(@data, 3, 'Regex works combined with other clausules (or)');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.name =~ /\[\w+\]/)]');
+is(@data, 1, 'A bit more complex regex. /\[\w+\]/');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.name =~ /\w{9}|\w{15}/)]');
+is(@data, 2, 'Another slightly complex regex. /\w{9}|\w{15}/');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.name =~ /\'\/Else\/\'/)]');
+is(@data, 1, 'Can use \' and / inside regex. /\'\/Else\/\'/');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.name =~ /"\/Else\/"/)]');
+is(@data, 0, 'Can use " and / inside regex. /"\/Else\/"/');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.name =~ /"@-\d\/\d\\\\.*"/)]');
+is(@data, 1, 'Try more special characers inside regex. /"@-\d\/\d\\\\.*"/');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.name =~ /"-\d\/\d\\\\.*"/)]');
+is(@data, 0, 'Similar but failing to match. /"-\d\/\d\\\\.*"/');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.name =~ /\] \(.*\'.*\/\d\\\\8\//)]');
+is(@data, 1, 'More weird expression. /\] \(.*\'.*\/\d\\\\8\//');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.name =~ /\(.*\)/)]');
+is(@data, 1, 'Escaped parenthesis are parenthesis. /\(.*\)/');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.name =~ /(.*)/)]');
+is(@data, 3, 'But not escaped parenthesis group stuff. /(.*)/');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.name =~ /^marketing|analysis$/i)]');
+is(@data, 2, 'Simple expression not grouped. /^marketing|analysis$/');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.name =~ /^(marketing|analysis)$/i)]');
+is(@data, 1, 'Simple expression now grouped. /^(marketing|analysis)$/');
+
+@data = evaluate_jsonpath($json, '$.Competency[?(@.name =~ /^(?:marketing|analysis)$/i)]');
+is(@data, 1, '?: has no effect. /^(?:marketing|analysis)$/');
+
+done_testing();

--- a/t/quotes-in-filter-expression.t
+++ b/t/quotes-in-filter-expression.t
@@ -5,8 +5,15 @@ local $JSON::Path::Safe = 0;
 #  use JSON::Path;
 #  use diagnostics;
 
-my $json =
-'{ "phones": [ { "type" : "iPhone", "number": "(123rpar 456-7890" }, { "type" : "home", "number": "(123) 456-7890" } ] }';
+my $json = q|{
+  "phones": [
+    { "type" : "iPhone", "number": "(123rpar 456-7890" },
+    { "type" : "home", "number": "(123) 456-7890" },
+    { "type" : "''\"']w[(o)\\r{k}'\"''", "number": "987 654 321" }
+  ]
+}|;
+use Data::Dumper;
+warn(Dumper($json));
 
 my $phone_number;
 $phone_number = '(123) 456-7890';
@@ -17,4 +24,10 @@ my $jpath =
   JSON::Path->new('$.phones.[?($_->{number} eq "(123) 456-7890")].type');
 my @types = $jpath->values($json);
 is($types[0], "home", "Got the right type");
+
+local $JSON::Path::Safe = 1;
+$jpath = JSON::Path->new(q|$.phones[?(@.type == "''\"']w[(o)\\r{k}'\"''")]|);
+@types = $jpath->paths($json);
+is($types[0], q|$['phones']['2']|, "Got the right type with insane quotes all around");
+
 done_testing();


### PR DESCRIPTION
Add regular expressions so a filter can be used in the form
```
  $.Parent[?(@.filter_key =~ /regex/)]
```
Regexes are not part of Goessner JSONPath but are a nice addition introduced in [Jayway JsonPath](https://github.com/json-path/JsonPath).

Also, fixex tokenizer so quotes and escaped characters are handled correctly inside quoted text.