### PR TITLE
Issue #42 eliminate json parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ version 1.0.3
 
     my $data = {
      "store" => {
-       "book" => [ 
+       "book" => [
          { "category" =>  "reference",
            "author"   =>  "Nigel Rees",
            "title"    =>  "Sayings of the Century",
@@ -41,17 +41,17 @@ version 1.0.3
        ],
      },
     };
-    
+
     use JSON::Path 'jpath_map';
 
     # All books in the store
     my $jpath   = JSON::Path->new('$.store.book[*]');
     my @books   = $jpath->values($data);
-    
+
     # The author of the last (by order) book
     my $jpath   = JSON::Path->new('$..book[-1:].author');
     my $tolkien = $jpath->value($data);
-    
+
     # Convert all authors to uppercase
     jpath_map { uc $_ } $data, '$.store.book[*].author';
 
@@ -107,7 +107,7 @@ JSONPath is described at [http://goessner.net/articles/JsonPath/](http://goessne
 - `set($object, $value, $limit)`
 
     Alters `$object`, setting the paths to `$value`. If set, then
-    `$limit` limits the number of changes made. 
+    `$limit` limits the number of changes made.
 
     TAKE NOTE! This will create keys in $object. E.G.:
 
@@ -151,7 +151,7 @@ by default:
 
 - `jpath_map { CODE } $object, $path_string`
 
-    Shortcut for `JSON::Path->new($path_string)->map($object, $code)`. 
+    Shortcut for `JSON::Path->new($path_string)->map($object, $code)`.
 
 # NAME
 
@@ -233,7 +233,7 @@ Kit Peters <popefelix@cpan.org>
 
 # CONTRIBUTORS
 
-Szymon Nieznański <s.nez@member.fsf.org> 
+Szymon Nieznański <s.nez@member.fsf.org>
 
 Kit Peters <popefelix@cpan.org>
 

--- a/cpanfile
+++ b/cpanfile
@@ -6,7 +6,6 @@ requires 'List::Util' => '1.45';    # For uniq.
 requires 'Readonly';
 requires 'Try::Tiny';
 requires 'perl' => '5.010';
-requires 'JSON::Parse';
 requires 'Tie::IxHash';
 
 on test => sub {

--- a/t/evaluator/path-construction-fail.t
+++ b/t/evaluator/path-construction-fail.t
@@ -1,9 +1,9 @@
 use Test2::V0 '-target' => 'JSON::Path';
+use JSON::MaybeXS qw/decode_json/;
 
 # Test demonstrating RT #122109, "paths method succeeds in search but then fails on path construction"
 # https://rt.cpan.org/Ticket/Display.html?id=122109
 #
-use JSON::Parse 'parse_json';
 local $JSON::Path::Safe = 0;
 my $json = '{
    "4" : {
@@ -45,7 +45,7 @@ my $json = '{
       "id" : 5
    }
 }';
-my $json_hash = parse_json($json);
+my $json_hash = decode_json($json);
 my $p3        = $CLASS->new('$.[?($_->{name} eq "Email")]');
 my @paths;
 ok lives { @paths = $p3->paths($json_hash) }, q{paths() did not die} or diag qq{Caught exception: $@};


### PR DESCRIPTION
JSON::Parse is no longer used in _t/evaluator/path-construction-fail.t_. The requirement has been removed.