### PR TITLE
Do not require Tie::IxHash

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -6,7 +6,6 @@ requires 'List::Util' => '1.45';    # For uniq.
 requires 'Readonly';
 requires 'Try::Tiny';
 requires 'perl' => '5.010';
-requires 'Tie::IxHash';
 
 on test => sub {
     requires 'Test2::V0';

--- a/t/evaluator/paths.t
+++ b/t/evaluator/paths.t
@@ -2,7 +2,6 @@ use Test2::V0;
 use JSON::MaybeXS qw/encode_json decode_json/;
 use JSON::Path::Evaluator;
 use Storable qw(dclone);
-use Tie::IxHash;
 
 my $json = sample_json();
 my %data = %{ decode_json($json) };


### PR DESCRIPTION
Tie::IxHash was loaded in _t/evaluator/paths.t_ but not actually used.